### PR TITLE
refactor: replace bytemuck with zerocopy for type conversions in mult…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,8 +100,7 @@ serde_arrays = "0.1"
 bincode = "1.3.3"
 bytes = "1"
 yamux = "0.10"
-bytemuck = { version = "1.13", features = ["derive"] }
-zerocopy = "0.8"
+zerocopy = { version = "0.8", features = ["derive"] }
 serio = { version = "0.2" }
 
 # io

--- a/crates/clmul/Cargo.toml
+++ b/crates/clmul/Cargo.toml
@@ -9,7 +9,7 @@ workspace = true
 
 [dependencies]
 cfg-if.workspace = true
-bytemuck = { workspace = true, features = ["derive"] }
+zerocopy = { workspace = true }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures.workspace = true

--- a/crates/clmul/src/backend.rs
+++ b/crates/clmul/src/backend.rs
@@ -24,8 +24,8 @@ impl soft::Clmul {
             ((u as u128) << 64) | (l as u128)
         }
 
-        let x: u128 = bytemuck::cast(x);
-        let y: u128 = bytemuck::cast(y);
+        let x: u128 = zerocopy::transmute!(x);
+        let y: u128 = zerocopy::transmute!(y);
 
         let (x3, x2) = sep(y);
         let (x1, x0) = sep(x);
@@ -38,7 +38,7 @@ impl soft::Clmul {
         let (g1, g0) = sep(join(x3, d) << 7);
         let h1 = x3 ^ e1 ^ f1 ^ g1;
         let h0 = d ^ e0 ^ f0 ^ g0;
-        bytemuck::cast(join(x1 ^ h1, x0 ^ h0))
+        zerocopy::transmute!(join(x1 ^ h1, x0 ^ h0))
     }
 }
 

--- a/crates/clmul/src/backend/soft32.rs
+++ b/crates/clmul/src/backend/soft32.rs
@@ -25,13 +25,13 @@
 //! In other words, if we bit-reverse (over 32 bits) the operands, then we
 //! bit-reverse (over 64 bits) the result.
 
-use bytemuck::{Pod, Zeroable};
 use core::{num::Wrapping, ops::BitXor};
+use zerocopy::{IntoBytes, FromBytes};
 pub type Clmul = U32x4;
 
 /// 4 x `u32` values
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Pod, Zeroable)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, IntoBytes, FromBytes)]
 pub struct U32x4(u32, u32, u32, u32);
 
 impl From<U32x4> for [u8; 16] {
@@ -154,7 +154,7 @@ impl U32x4 {
     }
 }
 
-/// Multiplication in GF(2)[X], truncated to the low 32-bits, with “holes”
+/// Multiplication in GF(2)[X], truncated to the low 32-bits, with "holes"
 /// (sequences of zeroes) to avoid carry spilling.
 ///
 /// When carries do occur, they wind up in a "hole" and are subsequently masked

--- a/crates/clmul/src/backend/soft64.rs
+++ b/crates/clmul/src/backend/soft64.rs
@@ -4,13 +4,13 @@
 //! <https://bearssl.org/gitweb/?p=BearSSL;a=blob;f=src/hash/ghash_ctmul64.c;hb=4b6046412>
 //!
 //! Copyright (c) 2016 Thomas Pornin <pornin@bolet.org>
-use bytemuck::{Pod, Zeroable};
 use core::{num::Wrapping, ops::BitXor};
+use zerocopy::{IntoBytes, FromBytes};
 pub type Clmul = U64x2;
 
 /// 2 x `u64` values
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Pod, Zeroable)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, IntoBytes, FromBytes)]
 pub struct U64x2(u64, u64);
 
 impl From<U64x2> for [u8; 16] {
@@ -77,7 +77,7 @@ impl U64x2 {
     }
 }
 
-/// Multiplication in GF(2)[X], truncated to the low 64-bits, with “holes”
+/// Multiplication in GF(2)[X], truncated to the low 64-bits, with "holes"
 /// (sequences of zeroes) to avoid carry spilling.
 ///
 /// When carries do occur, they wind up in a "hole" and are subsequently masked

--- a/crates/mpz-core/Cargo.toml
+++ b/crates/mpz-core/Cargo.toml
@@ -28,7 +28,7 @@ itybity.workspace = true
 opaque-debug.workspace = true
 bcs = "0.1.5"
 rand_core = "0.6.4"
-bytemuck = { workspace = true, features = ["derive"] }
+zerocopy = { workspace = true }
 generic-array.workspace = true
 rayon = { workspace = true, optional = true }
 cfg-if.workspace = true

--- a/crates/mpz-core/src/block.rs
+++ b/crates/mpz-core/src/block.rs
@@ -1,6 +1,5 @@
 //! A block of 128 bits and its operations.
 
-use bytemuck::{Pod, Zeroable};
 use clmul::Clmul;
 use core::ops::{BitAnd, BitAndAssign, BitXor, BitXorAssign};
 use generic_array::{typenum::consts::U16, GenericArray};
@@ -11,10 +10,11 @@ use std::{
     fmt::{Debug, Display},
     slice::from_raw_parts,
 };
+use zerocopy::{Immutable, IntoBytes, FromBytes};
 
 /// A block of 128 bits
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize, Pod, Zeroable)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize, IntoBytes, FromBytes, Immutable)]
 pub struct Block([u8; 16]);
 
 impl Block {
@@ -142,13 +142,15 @@ impl Block {
         (self.0[0] & 1) == 1
     }
 
-    /// Let `x0` and `x1` be the lower and higher halves of `x`, respectively.
     /// This function compute ``sigma( x = x0 || x1 ) = x1 || (x0 xor x1)``.
     #[inline(always)]
     pub fn sigma(a: Self) -> Self {
-        let mut x: [u64; 2] = bytemuck::cast(a);
-        x[0] ^= x[1];
-        bytemuck::cast([x[1], x[0]])
+        let val = u128::from_le_bytes(a.0);
+        let low = (val & u64::MAX as u128) as u64;
+        let high = (val >> 64) as u64;
+        let new_low = low ^ high;
+        let result_val = ((new_low as u128) << 64) | (high as u128);
+        Block(result_val.to_le_bytes())
     }
 
     /// Converts a slice of blocks to a slice of bytes.
@@ -268,7 +270,9 @@ impl From<[u8; 16]> for Block {
 
 impl<'a> From<&'a [u8; 16]> for &'a Block {
     fn from(bytes: &'a [u8; 16]) -> Self {
-        bytemuck::cast_ref(bytes)
+        // This should now be safe as Block is repr(transparent)
+        // over [u8; 16], sharing the same layout and alignment.
+        zerocopy::transmute_ref!(bytes)
     }
 }
 

--- a/crates/mpz-core/src/lpn.rs
+++ b/crates/mpz-core/src/lpn.rs
@@ -6,6 +6,7 @@ use crate::{prp::Prp, Block};
 use rand::Rng;
 use rayon::prelude::*;
 
+
 /// An LPN encoder.
 ///
 /// The `seed` defines a sparse binary matrix `A` with at most `D` non-zero
@@ -48,11 +49,17 @@ impl<const D: usize> LpnEncoder<D> {
         let mut index: [Block; D] = std::array::from_fn(|_| {
             let i = cnt;
             cnt += 1;
-            Block::from(bytemuck::cast::<_, [u8; 16]>([pos as u64, i]))
+            let bytes: [u8; 16] = zerocopy::transmute!([pos as u64, i]);
+            Block::from(bytes)
         });
 
         prp.permute_many_blocks(&mut index);
-        let index = bytemuck::cast_slice_mut::<_, u32>(&mut index);
+        // SAFETY: Block is repr(transparent) over [u8; 16] (128 bits).
+        // Transmuting to a slice of u32 (32 bits) is safe if length is correct.
+        let index: &mut [u32] = unsafe {
+            let len = index.len() * (Block::LEN / std::mem::size_of::<u32>());
+            std::slice::from_raw_parts_mut(index.as_mut_ptr() as *mut u32, len)
+        };
 
         for (i, y) in y.iter_mut().enumerate().take(4) {
             for ind in index[i * D..(i + 1) * D].iter_mut() {
@@ -69,10 +76,19 @@ impl<const D: usize> LpnEncoder<D> {
         // (D + 4 - 1) / 4
         let block_size = D.div_ceil(4);
         let mut index = (0..block_size)
-            .map(|i| Block::from(bytemuck::cast::<_, [u8; 16]>([pos as u64, i as u64])))
+            .map(|i| {
+                let bytes: [u8; 16] = zerocopy::transmute!([pos as u64, i as u64]);
+                Block::from(bytes)
+            })
             .collect::<Vec<Block>>();
         prp.permute_block_inplace(&mut index);
-        let index = bytemuck::cast_slice_mut::<_, u32>(&mut index);
+        // SAFETY: Block is repr(transparent) over [u8; 16] (128 bits).
+        // Transmuting to a slice of u32 (32 bits) is safe if length is correct.
+        let index_slice = index.as_mut_slice();
+        let index: &mut [u32] = unsafe {
+            let len = index_slice.len() * (Block::LEN / std::mem::size_of::<u32>());
+            std::slice::from_raw_parts_mut(index_slice.as_mut_ptr() as *mut u32, len)
+        };
 
         for ind in index.iter_mut().take(D) {
             *ind &= self.mask;
@@ -179,6 +195,7 @@ impl LpnParameters {
 mod tests {
     use crate::{lpn::LpnEncoder, prp::Prp, Block};
 
+
     impl<const D: usize> LpnEncoder<D> {
         #[allow(dead_code)]
         fn compute_four_rows_non_indep(&self, y: &mut [Block], x: &[Block], pos: usize, prp: &Prp) {
@@ -186,11 +203,17 @@ mod tests {
             let mut index = [0; D].map(|_| {
                 let i: u64 = cnt;
                 cnt += 1;
-                Block::from(bytemuck::cast::<_, [u8; 16]>([pos as u64, i]))
+                let bytes: [u8; 16] = zerocopy::transmute!([pos as u64, i]);
+                Block::from(bytes)
             });
 
             prp.permute_many_blocks(&mut index);
-            let index: &mut [u32] = bytemuck::cast_slice_mut::<_, u32>(&mut index);
+            // SAFETY: Block is repr(transparent) over [u8; 16] (128 bits).
+            // Transmuting to a slice of u32 (32 bits) is safe if length is correct.
+            let index: &mut [u32] = unsafe {
+                let len = index.len() * (Block::LEN / std::mem::size_of::<u32>());
+                std::slice::from_raw_parts_mut(index.as_mut_ptr() as *mut u32, len)
+            };
 
             for (i, y) in y[pos..].iter_mut().enumerate().take(4) {
                 for ind in index[i * D..(i + 1) * D].iter_mut() {

--- a/crates/mpz-core/src/prg.rs
+++ b/crates/mpz-core/src/prg.rs
@@ -40,7 +40,7 @@ impl BlockRngCore for PrgCore {
             },
         );
         self.aes.encrypt_many_blocks(&mut states);
-        *results = bytemuck::cast(states);
+        *results = zerocopy::transmute!(states);
     }
 }
 
@@ -179,7 +179,11 @@ impl Prg {
     /// Fill a block slice with random block values.
     #[inline(always)]
     pub fn random_blocks(&mut self, buf: &mut [Block]) {
-        let bytes: &mut [u8] = bytemuck::cast_slice_mut(buf);
+        let len = buf.len();
+        // SAFETY: Block is repr(transparent) over [u8; 16]
+        let bytes: &mut [u8] = unsafe {
+            std::slice::from_raw_parts_mut(buf.as_mut_ptr() as *mut u8, len * Block::LEN)
+        };
         self.fill_bytes(bytes);
     }
 }

--- a/crates/mpz-ot-core/Cargo.toml
+++ b/crates/mpz-ot-core/Cargo.toml
@@ -37,7 +37,6 @@ derive_builder.workspace = true
 itybity.workspace = true
 opaque-debug.workspace = true
 cfg-if.workspace = true
-bytemuck = { workspace = true, features = ["derive"] }
 enum-try-as-inner.workspace = true
 futures = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }

--- a/crates/mpz-ot-core/src/ferret/cuckoo.rs
+++ b/crates/mpz-ot-core/src/ferret/cuckoo.rs
@@ -156,7 +156,7 @@ fn compute_table_length(t: usize) -> usize {
 // Hash the value into index using AES.
 #[inline(always)]
 fn hash_to_index(hash: &AesEncryptor, range: usize, value: u32) -> usize {
-    let mut blk: Block = bytemuck::cast::<_, Block>(value as u128);
+    let mut blk: Block = zerocopy::transmute!(value as u128);
     blk = hash.encrypt_block(blk);
     let res = u128::from_le_bytes(blk.to_bytes());
     (res as usize) % range


### PR DESCRIPTION
…iple crates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management by replacing an existing byte conversion library with an alternative for consistent handling across the project.
  
- **Refactor**
  - Revised internal type conversion routines and data handling techniques to improve safety and coherence while maintaining external functionality.
  
- **Style**
  - Standardized comment formatting for better clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->